### PR TITLE
Various k8s Improvements

### DIFF
--- a/container-mpd/mpd.conf
+++ b/container-mpd/mpd.conf
@@ -8,7 +8,7 @@
 # be disabled and audio files will only be accepted over ipc socket (using
 # file:// protocol) or streaming files over an accepted protocol.
 #
-music_directory         "/var/lib/mpd/music"
+music_directory         "/music"
 #
 # This setting sets the MPD internal playlist directory. The purpose of this
 # directory is storage for playlists created by MPD. The server will use
@@ -33,7 +33,7 @@ db_file                 "/var/lib/mpd/tag_cache"
 # setting defaults to logging to syslog, or to journal if mpd was started as
 # a systemd service.
 #
-log_file                "/var/log/mpd/mpd.log"
+log_file                "syslog"
 #
 # This setting sets the location of the file which stores the process ID
 # for use of mpd --kill and some init scripts. This setting is disabled by
@@ -168,7 +168,7 @@ password                "mpcpyapp@read"
 #
 # This setting specifies the permissions a user has who has not yet logged in.
 #
-default_permissions    ""
+#default_permissions    "read,add,control,admin"
 #
 ###############################################################################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     container_name: backendmpd
     restart: on-failure:5
     volumes:
-        - ./music/db:/var/lib/mpd/music:ro
+        - ./music/db:/music:ro
     cap_drop:
       - net_bind_service
       - chown

--- a/kubernetes/.gitignore
+++ b/kubernetes/.gitignore
@@ -1,2 +1,2 @@
 pv-*
-./ingress.yaml
+ingress.yaml

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -43,8 +43,20 @@ See [ingress][docs-ingress] documentation for more information.
 
 After copying and editing what you need from `/kubernetes/examples/` to `/kubernetes/` for the configuration of your music volume you can apply the Kubernetes manifests to bring up MPContainer:
 
+### Namespace
+
 ```shell
 kubectl apply -f ./kubernetes/namespace.yaml
+```
+## Configure a configMap for MPD configuration
+
+```shell
+kubectl create configmap mpdconf --from-file=container-mpd/mpd.conf --namespace musicplayer
+```
+
+### Deploy services
+
+```shell
 kubectl apply -f ./kubernetes/
 ```
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -6,18 +6,16 @@ We need to have some config that will point to where the music is.
 
 Copy the yaml config files you need for your environment into the kubernetes dir, make sure the files are prefixed with `pv-` so they will be ignored by Git.
 
-```shell
-cp kubernetes/examples/pv-claim-nfs.yaml kubernetes/pv-claim-nfs.yaml
-cp kubernetes/examples/pv-store-nfs.yaml kubernetes/pv-store-nfs.yaml
-```
+This example uses NFS, for local storage use `-dev`. 
 
-You will then need to update the values in `pv-store-nfs.yaml`
-
-This example uses NFS, for local storage use `-dev`. If you are using NFS your Nodes will also need NFS tools to be able to mount the volume:
+If you are using NFS your Nodes will also need NFS tools to be able to mount the volume:
 
 ```shell
 apt install -y nfs-common
+cp kubernetes/examples/pv-*-nfs.yaml kubernetes/
 ```
+
+You will then need to update the values in `pv-store-nfs.yaml` and `pv-store-config-nfs.yaml`
 
 See [persistent volumes][docs-pv] documentation for more information.
 

--- a/kubernetes/app-mpd.yaml
+++ b/kubernetes/app-mpd.yaml
@@ -62,14 +62,37 @@ spec:
             - -h
             - DJp455w0rd101@localhost
             - outputs
+          initialDelaySeconds: 20
+          periodSeconds: 10
           timeoutSeconds: 30
         tty: true
         volumeMounts:
-        - name: music
-          mountPath: /var/lib/mpd/music
+        - mountPath: /music
+          name: music
+        - mountPath: /var/lib/mpd/playlists/
+          name: config
+          subPath: playlists
+        - mountPath: /etc/mpd.conf
+          name: etc
+          subPath: mpd.conf
+      initContainers:
+      - name: install
+        image: busybox
+        command: [ 'sh', '-c', "mkdir -p /var/lib/mpd/playlists" ]
+        volumeMounts:
+        - mountPath: /var/lib/mpd/
+          name: config
       restartPolicy: Always
       serviceAccountName: ""
       volumes:
       - name: music
         persistentVolumeClaim:
           claimName: music-claim
+      - name: config
+        persistentVolumeClaim:
+          claimName: config-claim
+      - name: etc
+        configMap:
+          name: mpdconf
+      - name: empty
+        emptyDir: {}

--- a/kubernetes/app-pyapp.yaml
+++ b/kubernetes/app-pyapp.yaml
@@ -21,7 +21,7 @@ metadata:
   name: mpcpyapp
   namespace: musicplayer
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       mp.service: mpcpyapp

--- a/kubernetes/app-web.yaml
+++ b/kubernetes/app-web.yaml
@@ -21,7 +21,7 @@ metadata:
   name: backendweb
   namespace: musicplayer
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       mp.service: backendweb

--- a/kubernetes/examples/pv-config-claim.yaml
+++ b/kubernetes/examples/pv-config-claim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: config-claim
+  namespace: musicplayer
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 2G
+  selector:
+    matchLabels:
+      type: "config"

--- a/kubernetes/examples/pv-store-config-nfs.yaml
+++ b/kubernetes/examples/pv-store-config-nfs.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: config-pv
+  namespace: musicplayer
+  labels:
+    type: config
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow
+  mountOptions:
+    - rw
+  capacity:
+    storage: 2G
+  nfs:
+    path: /some/path
+    server: nfs-server-name-or-ip

--- a/music/db/readme.txt
+++ b/music/db/readme.txt
@@ -1,8 +1,8 @@
 # Readme.txt
 
-The MPD music folder - put your mp3 here!
+The MPD music folder - put your music files here!
 
-In the container the path is /var/lib/mpd/music/
+In the container the path is /music/
 
 For testing there are some good, free, and legal albums you can download:
 


### PR DESCRIPTION
Includes the following:

- `mpd.conf` as a [configMap](https://kubernetes.io/docs/concepts/configuration/configmap/), removing the dependence on the config file baked into the image
- Update to use `/music` as main music folder in the container. This had been nested inside of the /var/lib/mpd directory which wasn't ideal in some situations as config lives in here also. As we're running containers having a root /music should be OK. Updated compose and docs to reflect this.
- Update to log mpd to 'syslog' output rather than a flat file inside the container.
- Add a persistent volume to mount a config directory rw allowing for saving of playlists.